### PR TITLE
fix: 🐛 Handle case when create field is null

### DIFF
--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -41,11 +41,11 @@ class Transformer extends Transform {
                 // TODO: handle deleted action
                 const createdCol = options.createdColumnName || '_created'
                 const modifiedCol = options.modifiedColumnName || '_modified'
-                const created = new Date(row[createdCol])
                 const modified = new Date(row[modifiedCol])
                 const since = new Date(options.since)
+                const created = row[createdCol] ? new Date(row[createdCol]) : modified
 
-                if (modified >= since && created >= since) {
+                if (modified >= since && created > since) {
                   return options.actionAliases.insert
                 }
                 if (modified >= since && created <= since) {

--- a/test/fixtures/expected/multiple-delta.csv
+++ b/test/fixtures/expected/multiple-delta.csv
@@ -3,4 +3,4 @@
 74,"i","2 Evergreen Terrace",6
 73,"u",5,"Montgomery","Burns",123
 73,"u",6,"Ned","Flanders",60
-73,"u",8,"Bart","Simpson",10
+73,"i",8,"Bart","Simpson",10

--- a/test/fixtures/install-test-schemas.sql
+++ b/test/fixtures/install-test-schemas.sql
@@ -18,7 +18,7 @@ INSERT INTO springfield.people (hash_sum, social_security_id, first_name, last_n
 ('BBBBBBBB', 2, 'Marge', 'Simpson', 36, '2016-06-02 15:00:01.000000 GMT', '2017-06-01 15:02:38.000000 GMT'),
 ('EEEEEEEE', 5, 'Montgomery', 'Burns', 123, '2017-06-02 15:00:01.000000 GMT', '2017-06-02 15:02:39.000000 GMT'),
 ('11111111', 6, 'Ned', 'Flanders', 60, '2017-06-02 15:00:01.000000 GMT', '2017-06-02 15:02:40.000000 GMT'),
-('22222222', 8, 'Bart', 'Simpson', 10, '2017-06-02 15:00:01.000000 GMT', '2017-06-02 18:42:12.000000 BST');
+('22222222', 8, 'Bart', 'Simpson', 10, null, '2017-06-02 18:42:12.000000 BST');
 
 CREATE TABLE springfield.homes (
   id integer NOT NULL,


### PR DESCRIPTION
If create date is null, default it to the modified date when generating the output. 