### PR TITLE
New option - deletesFunction(namespace,model,dataSince,oStream)

### DIFF
--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -3,10 +3,10 @@ const csvEncoder = require('./simple-csv-encoder')
 const DateTime = require('luxon').DateTime
 
 class Transformer extends Transform {
-  constructor (info, model, options) {
+  constructor (info, model, options, processingDeletes) {
     super({ objectMode: true })
     this.info = info
-    this.modelInfo = { totalCount: 0 }
+    this.modelInfo = this.info[model] || { totalCount: 0 }
     this.info[model] = this.modelInfo
 
     const transformers = options.transformFunction ? options.transformFunction : identityTransform
@@ -29,6 +29,8 @@ class Transformer extends Transform {
 
     this.progressCallback = options.progressCallback
 
+    const actionTransformer = !processingDeletes ? insertOrUpdateAction(options) : deleteAction(options)
+
     this.transformers = options.csvExtracts[model].map(csvColumnSource => {
       switch (csvColumnSource[0]) {
         case '$': {
@@ -37,21 +39,7 @@ class Transformer extends Transform {
             case 'ROW_NUM':
               return (row, info) => info.totalCount
             case 'ACTION':
-              return row => {
-                // TODO: handle deleted action
-                const createdCol = options.createdColumnName || '_created'
-                const modifiedCol = options.modifiedColumnName || '_modified'
-                const created = new Date(row[createdCol])
-                const modified = new Date(row[modifiedCol])
-                const since = new Date(options.since)
-
-                if (modified >= since && created >= since) {
-                  return options.actionAliases.insert
-                }
-                if (modified >= since && created <= since) {
-                  return options.actionAliases.update
-                }
-              }
+              return actionTransformer
             case 'TIMESTAMP':
               return () => DateTime.local().toLocaleString(DateTime.TIME_24_WITH_SECONDS)
             case 'DATESTAMP':
@@ -120,6 +108,27 @@ class Transformer extends Transform {
 
 function identityTransform (row, callback) {
   callback(null, row)
+}
+
+function insertOrUpdateAction (options) {
+  return row => {
+    const createdCol = options.createdColumnName || '_created'
+    const modifiedCol = options.modifiedColumnName || '_modified'
+    const created = new Date(row[createdCol])
+    const modified = new Date(row[modifiedCol])
+    const since = new Date(options.since)
+
+    if (modified >= since && created >= since) {
+      return options.actionAliases.insert
+    }
+    if (modified >= since && created <= since) {
+      return options.actionAliases.update
+    }
+  }
+}
+
+function deleteAction (options) {
+  return () => options.actionAliases.delete
 }
 
 module.exports = Transformer

--- a/lib/generate-delta.js
+++ b/lib/generate-delta.js
@@ -20,6 +20,8 @@ module.exports = async function generateDelta (options) {
       }
 
       await extractModel(info, model, options, deltaFileWriteStream)
+
+      await processDeletes(info, model, options, deltaFileWriteStream)
     }
   } finally {
     progressCallback(info, true)
@@ -73,3 +75,12 @@ function tableName (namespace, model) {
 
   return (separator === -1) ? `${snakeCase(namespace)}.${model}` : model
 } // tableName
+
+function processDeletes (info, model, options, outStream) {
+  if (!options.deletesFunction) { return }
+  const csvTransformer = new Transformer(info, model, options, true)
+  csvTransformer.pipe(outStream, { end: false })
+
+  const since = new Date(options.since)
+  return options.deletesFunction(options.namespace, model, since, csvTransformer)
+}

--- a/test/fixtures/expected/with-deletes.csv
+++ b/test/fixtures/expected/with-deletes.csv
@@ -1,0 +1,6 @@
+73,"i",1,1,"Homer","Simpson",39
+73,"u",2,2,"Marge","Simpson",36
+73,"i",3,5,"Montgomery","Burns",123
+73,"i",4,6,"Ned","Flanders",60
+73,"i",5,8,"Bart","Simpson",10
+73,"d",6,99,"Marvin","Monroe",45

--- a/test/tests.js
+++ b/test/tests.js
@@ -264,6 +264,45 @@ describe('Run the basic usage example', function () {
           ]
         }
       }
+    },
+    {
+      name: 'delta with delete',
+      file: 'with-deletes.csv',
+      count: 6,
+      info: {
+        totalCount: 6,
+        people: {
+          totalCount: 6
+        }
+      },
+      delta: {
+        namespace: 'springfield',
+        since: '2016-06-03 15:02:38.000000 GMT',
+        actionAliases: {
+          insert: 'i',
+          update: 'u',
+          delete: 'd'
+        },
+        deletesFunction: function (namespace, tableName, sinceDate, outputStream) {
+          outputStream.write({
+            social_security_id: 99,
+            first_name: 'Marvin',
+            last_name: 'Monroe',
+            age: 45
+          })
+        },
+        csvExtracts: {
+          people: [
+            73,
+            '$ACTION',
+            '$ROW_NUM',
+            '@social_security_id',
+            '@first_name',
+            '@last_name',
+            '@age'
+          ]
+        }
+      }
     }
   ]
 


### PR DESCRIPTION
Ordinarily, pg-delta-file can only detect new or updated records. The deletesFunction allows the caller to inject, by whatever means, rows that have been removed into the delta file. These rows will be processed in the same way as other rows - added to counts, reported through the progress callback, etc - but their action column will be deleted.

Story details: https://app.clubhouse.io/wmfs/story/5092